### PR TITLE
Fix MSVC ICE and warnings

### DIFF
--- a/external/include/data_parser.hpp
+++ b/external/include/data_parser.hpp
@@ -18,13 +18,15 @@
  */
 
 #pragma once
+
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
 
-inline auto parse_data_file_double_det(const std::string& filename)
+inline auto parse_data_file_double_det(const std::filesystem::path& filename)
 	-> std::tuple<std::vector<std::vector<double>>, double, bool>
 {
 	auto file   = std::ifstream{ filename };
@@ -65,7 +67,7 @@ inline auto parse_data_file_double_det(const std::string& filename)
 	return { data, result, file.is_open() };
 }
 
-inline auto parse_data_file_matrix_transformation_double(const std::string& filename)
+inline auto parse_data_file_matrix_transformation_double(const std::filesystem::path& filename)
 	-> std::tuple<std::vector<std::vector<double>>, std::vector<std::vector<double>>, bool>
 {
 	auto file   = std::ifstream{ filename };
@@ -116,7 +118,7 @@ inline auto parse_data_file_matrix_transformation_double(const std::string& file
 	return { data, result, file.is_open() };
 }
 
-inline auto parse_data_file_matrix_block_double(const std::string& filename)
+inline auto parse_data_file_matrix_block_double(const std::filesystem::path& filename)
 	-> std::tuple<std::vector<std::vector<double>>,
 		std::vector<std::tuple<std::size_t, std::size_t, std::size_t, std::size_t, std::vector<std::vector<double>>>>,
 		bool>

--- a/include/mpp/algorithm/inverse.hpp
+++ b/include/mpp/algorithm/inverse.hpp
@@ -89,8 +89,8 @@ namespace mpp
 						auto diag_row_idx        = idx_2d_to_1d(cols, col_idx, col_2_idx);
 						const auto diag_row_elem = u_buf[diag_row_idx];
 
-						const auto elem_idx = idx_2d_to_1d(cols, row_idx, col_2_idx);
-						const auto elem     = u_buf[elem_idx];
+						const auto cur_elem_idx = idx_2d_to_1d(cols, row_idx, col_2_idx);
+						const auto elem     = u_buf[cur_elem_idx];
 						const auto factor   = elem_before_factor * -1;
 
 						const auto new_elem = factor * diag_row_elem + elem;

--- a/include/mpp/algorithm/inverse.hpp
+++ b/include/mpp/algorithm/inverse.hpp
@@ -90,8 +90,8 @@ namespace mpp
 						const auto diag_row_elem = u_buf[diag_row_idx];
 
 						const auto cur_elem_idx = idx_2d_to_1d(cols, row_idx, col_2_idx);
-						const auto elem     = u_buf[cur_elem_idx];
-						const auto factor   = elem_before_factor * -1;
+						const auto elem         = u_buf[cur_elem_idx];
+						const auto factor       = elem_before_factor * -1;
 
 						const auto new_elem = factor * diag_row_elem + elem;
 						u_buf[elem_idx]     = new_elem;

--- a/include/mpp/detail/matrix_base.hpp
+++ b/include/mpp/detail/matrix_base.hpp
@@ -151,7 +151,8 @@ namespace mpp::detail
 			}
 		}
 
-		void init_buf_2d_dynamic_without_check(const auto& rng_2d, std::size_t rows, std::size_t cols) // @TODO: ISSUE #20
+		void
+		init_buf_2d_dynamic_without_check(const auto& rng_2d, std::size_t rows, std::size_t cols) // @TODO: ISSUE #20
 		{
 			_rows = rows;
 			_cols = cols;
@@ -483,7 +484,7 @@ namespace mpp::detail
 
 					for (auto&& val : rng)
 					{
-					    base._buf.push_back(std::move(static_cast<Value>(val)));
+						base._buf.push_back(std::move(static_cast<Value>(val)));
 					}
 				}
 				else
@@ -492,19 +493,19 @@ namespace mpp::detail
 
 					for (auto&& val : rng)
 					{
-					    base._buf[idx++] = std::move(static_cast<Value>(val));
+						base._buf[idx++] = std::move(static_cast<Value>(val));
 					}
 				}
 			}
 			else
 			{
-                if constexpr (is_vector<Buffer>::value)
+				if constexpr (is_vector<Buffer>::value)
 				{
 					base._buf.reserve(std::ranges::size(rng));
 
 					for (const auto& val : rng)
 					{
-					    base._buf.push_back(static_cast<Value>(val));
+						base._buf.push_back(static_cast<Value>(val));
 					}
 				}
 				else
@@ -513,7 +514,7 @@ namespace mpp::detail
 
 					for (const auto& val : rng)
 					{
-					    base._buf[idx++] = static_cast<Value>(val);
+						base._buf[idx++] = static_cast<Value>(val);
 					}
 				}
 			}

--- a/include/mpp/detail/matrix_base.hpp
+++ b/include/mpp/detail/matrix_base.hpp
@@ -151,7 +151,7 @@ namespace mpp::detail
 			}
 		}
 
-		void init_buf_2d_dynamic_without_check(auto&& rng_2d, std::size_t rows, std::size_t cols) // @TODO: ISSUE #20
+		void init_buf_2d_dynamic_without_check(const auto& rng_2d, std::size_t rows, std::size_t cols) // @TODO: ISSUE #20
 		{
 			_rows = rows;
 			_cols = cols;
@@ -215,7 +215,7 @@ namespace mpp::detail
 		}
 
 		void init_expr_dynamic_without_check(std::size_t rows, std::size_t cols,
-			auto&& expr) // @TODO: ISSUE #20
+			const auto& expr) // @TODO: ISSUE #20
 		{
 			_rows = rows;
 			_cols = cols;
@@ -465,7 +465,7 @@ namespace mpp::detail
 
 		friend inline void init_matrix_with_1d_rng(
 			matrix_base<Buffer, Value, RowsExtent, ColumnsExtent, Allocator>& base,
-			auto&& rng,
+			const auto& rng,
 			std::size_t rows,
 			std::size_t cols) // @TODO: ISSUE #20
 		{
@@ -474,26 +474,47 @@ namespace mpp::detail
 
 			reserve_1d_buf_if_vector(base._buf, rows, cols);
 
+			// @FIXME: Probably not optimal. Look at this again later
 			if constexpr (std::is_rvalue_reference_v<decltype(rng)>)
 			{
 				if constexpr (is_vector<Buffer>::value)
 				{
-					std::ranges::move(rng, std::back_inserter(base._buf));
+					base._buf.reserve(std::ranges::size(rng));
+
+					for (auto&& val : rng)
+					{
+					    base._buf.push_back(std::move(static_cast<Value>(val)));
+					}
 				}
 				else
 				{
-					std::ranges::move(rng, base._buf.begin());
+					auto idx = std::size_t{};
+
+					for (auto&& val : rng)
+					{
+					    base._buf[idx++] = std::move(static_cast<Value>(val));
+					}
 				}
 			}
 			else
 			{
-				if constexpr (is_vector<Buffer>::value)
+                if constexpr (is_vector<Buffer>::value)
 				{
-					std::ranges::copy(rng, std::back_inserter(base._buf));
+					base._buf.reserve(std::ranges::size(rng));
+
+					for (const auto& val : rng)
+					{
+					    base._buf.push_back(static_cast<Value>(val));
+					}
 				}
 				else
 				{
-					std::ranges::copy(rng, base._buf.begin());
+					auto idx = std::size_t{};
+
+					for (const auto& val : rng)
+					{
+					    base._buf[idx++] = static_cast<Value>(val);
+					}
 				}
 			}
 		}

--- a/include/mpp/detail/utility.hpp
+++ b/include/mpp/detail/utility.hpp
@@ -94,7 +94,7 @@ namespace mpp::detail
 		}
 	}
 
-	inline void validate_same_size(auto&& left, auto&& right) // @TODO: ISSUE #20
+	inline void validate_same_size(const auto& left, const auto& right) // @TODO: ISSUE #20
 	{
 		if (left.rows() != right.rows() || left.columns() != right.columns())
 		{
@@ -102,7 +102,7 @@ namespace mpp::detail
 		}
 	}
 
-	inline void validate_matrices_multipliable(auto&& left, auto&& right) // @TODO: ISSUE #20
+	inline void validate_matrices_multipliable(const auto& left, const auto& right) // @TODO: ISSUE #20
 	{
 		if (left.columns() != right.rows())
 		{
@@ -127,10 +127,15 @@ namespace mpp::detail
 	inline void
 	allocate_1d_buf_if_vector(auto& buf, std::size_t rows, std::size_t cols, InitializerValue&& val) // @TODO: ISSUE #20
 	{
+		// @TODO: Remove this workaround once MSVC supports requires clauses (#188)
+#ifdef _MSC_VER
+        constexpr auto is_vec = is_vector<std::remove_cvref_t<decltype(buf)>>::value;
+#else
 		constexpr auto is_vec = requires
 		{
 			buf.reserve(0);
 		};
+#endif
 
 		if constexpr (is_vec)
 		{
@@ -140,10 +145,15 @@ namespace mpp::detail
 
 	inline void reserve_1d_buf_if_vector(auto& buf, std::size_t rows, std::size_t cols) // @TODO: ISSUE #20
 	{
+	// @TODO: Remove this workaround once MSVC supports requires clauses (#188)
+#ifdef _MSC_VER
+        constexpr auto is_vec = is_vector<std::remove_cvref_t<decltype(buf)>>::value;
+#else
 		constexpr auto is_vec = requires
 		{
 			buf.reserve(0);
 		};
+#endif
 
 		if constexpr (is_vec)
 		{

--- a/include/mpp/detail/utility.hpp
+++ b/include/mpp/detail/utility.hpp
@@ -127,15 +127,7 @@ namespace mpp::detail
 	inline void
 	allocate_1d_buf_if_vector(auto& buf, std::size_t rows, std::size_t cols, InitializerValue&& val) // @TODO: ISSUE #20
 	{
-		// @TODO: Remove this workaround once MSVC supports requires clauses (#188)
-#ifdef _MSC_VER
-        constexpr auto is_vec = is_vector<std::remove_cvref_t<decltype(buf)>>::value;
-#else
-		constexpr auto is_vec = requires
-		{
-			buf.reserve(0);
-		};
-#endif
+		constexpr auto is_vec = is_vector<std::remove_cvref_t<decltype(buf)>>::value;
 
 		if constexpr (is_vec)
 		{
@@ -145,15 +137,7 @@ namespace mpp::detail
 
 	inline void reserve_1d_buf_if_vector(auto& buf, std::size_t rows, std::size_t cols) // @TODO: ISSUE #20
 	{
-	// @TODO: Remove this workaround once MSVC supports requires clauses (#188)
-#ifdef _MSC_VER
-        constexpr auto is_vec = is_vector<std::remove_cvref_t<decltype(buf)>>::value;
-#else
-		constexpr auto is_vec = requires
-		{
-			buf.reserve(0);
-		};
-#endif
+		constexpr auto is_vec = is_vector<std::remove_cvref_t<decltype(buf)>>::value;
 
 		if constexpr (is_vec)
 		{


### PR DESCRIPTION
- [ ] VS 16.9.0 is on Azure Pipelines

**Workers should be updated at the end of this week: https://github.com/actions/virtual-environments/issues/2878**

Fixes #187
Partially addresses #81

Few external changes had to happen:
- Replaced `auto&&` with `const auto&` in several helpers (determining whether this is a bug in the compiler or not)
- Correctly cast values for `cast` when calling `init_matrix_base_with_1d_rng`
- Fixed foreshadowing variable `elem_idx` in `inverse`