### PR TITLE
Strengthen noexcept

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A C++20 and later matrix library
 #### Tested Compilers to Compile Tests:
 
 - GCC 10
-- Clang 11 with libstdc++
+- Clang 11 with libstdc++ (Clang 11 has a ICE for noexcept specification for `mpp::elements_compare`, so the noexcept specification doesn't exist for that CPO)
 - MSVC 19.29 (VS 2019 16.10.2)
 
 ## How to Include:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A C++20 and later matrix library
 #### Tested Compilers to Compile Tests:
 
 - GCC 10
-- Clang 11 with libstdc++ (Clang 11 has a ICE for noexcept specification for `mpp::elements_compare`, so the noexcept specification doesn't exist for that CPO)
+- Clang 11 with libstdc++ (Clang 11 has a ICE for noexcept specification for `mpp::elements_compare`, so the noexcept specification doesn't exist for that CPO for Clang 11)
 - MSVC 19.29 (VS 2019 16.10.2)
 
 ## How to Include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,8 +64,8 @@ jobs:
         displayName: Install Python LLVM Lit
 
       - script: |
-          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=/usr/bin/g++-10 -DCMAKE_BUILD_TYPE=Release -B build
-          cmake --build build --target tests --config Release
+          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=/usr/bin/g++-10 -DCMAKE_BUILD_TYPE=Debug -B build
+          cmake --build build --target tests --config Debug
         displayName: Configure and Build Tests
 
       - script: |
@@ -95,8 +95,8 @@ jobs:
         displayName: Install Python LLVM Lit
 
       - script: |
-          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=/usr/bin/clang++-11 -DCMAKE_BUILD_TYPE=Release -B build
-          cmake --build build --target tests --config Release
+          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=/usr/bin/clang++-11 -DCMAKE_BUILD_TYPE=Debug -B build
+          cmake --build build --target tests --config Debug
         displayName: Configure and Build Tests
 
       - script: |
@@ -129,8 +129,8 @@ jobs:
       - script: |
           call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 
-          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Release -B build
-          cmake --build build --target tests --config Release
+          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=cl -DCMAKE_BUILD_TYPE=Debug -B build
+          cmake --build build --target tests --config Debug
         displayName: Configure and Build Tests
 
       - script: |
@@ -162,8 +162,8 @@ jobs:
       - script: |
           call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 
-          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_BUILD_TYPE=Release -G Ninja -B build
-          cmake --build build --target tests --config Release
+          cmake -DMPP_BUILD_TESTS=TRUE -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_BUILD_TYPE=Debug -G Ninja -B build
+          cmake --build build --target tests --config Debug
         displayName: Configure and Build Tests
 
       - script: |

--- a/external/include/utility.hpp
+++ b/external/include/utility.hpp
@@ -44,6 +44,10 @@
 
 using namespace boost::ut;
 
+// Forward declared from test_parsers.hpp
+template<typename...>
+struct types;
+
 template<class... Ts>
 struct overloaded : Ts...
 {
@@ -94,7 +98,7 @@ using dyn_mats_t = std::tuple<mpp::matrix<Val, mpp::dynamic, mpp::dynamic, Ts...
 	mpp::matrix<Val, mpp::dynamic, Columns, Ts...>>;
 
 inline auto fwd_args = []<typename T>(types<T>, auto&&... args) {
-	return T{ args... };
+	return T{ std::forward<decltype(args)>(args)... };
 };
 
 inline auto args = [](const auto& fn, auto&&... args) {

--- a/include/mpp/arithmetic/add.hpp
+++ b/include/mpp/arithmetic/add.hpp
@@ -34,8 +34,8 @@ namespace mpp
 		inline constexpr auto add_op = [](const auto& left,
 										   const auto& right,
 										   std::size_t row_index,
-										   std::size_t col_index) -> decltype(left(row_index, col_index) +
-																			  right(row_index, col_index)) {
+										   std::size_t col_index) noexcept -> decltype(left(row_index, col_index) +
+																					   right(row_index, col_index)) {
 			return left(row_index, col_index) + right(row_index, col_index);
 		};
 	} // namespace detail
@@ -49,7 +49,7 @@ namespace mpp
 		std::size_t RightColumnsExtent>
 	[[nodiscard]] inline auto operator+(
 		const detail::expr_base<LeftBase, Value, LeftRowsExtent, LeftColumnsExtent>& left,
-		const detail::expr_base<RightBase, Value, RightRowsExtent, RightColumnsExtent>& right)
+		const detail::expr_base<RightBase, Value, RightRowsExtent, RightColumnsExtent>& right) noexcept
 		-> detail::expr_binary_op<detail::prefer_static_extent(LeftRowsExtent, RightRowsExtent),
 			detail::prefer_static_extent(LeftColumnsExtent, RightColumnsExtent),
 			detail::expr_base<LeftBase, Value, LeftRowsExtent, LeftColumnsExtent>,

--- a/include/mpp/arithmetic/divide.hpp
+++ b/include/mpp/arithmetic/divide.hpp
@@ -35,7 +35,8 @@ namespace mpp
 		inline constexpr auto div_op = [](const auto& lhs,
 										   const auto& rhs,
 										   std::size_t row_index,
-										   std::size_t column_index) -> decltype(lhs(row_index, column_index) / rhs) {
+										   std::size_t column_index) noexcept -> decltype(lhs(row_index, column_index) /
+																						  rhs) {
 			return lhs(row_index, column_index) / rhs;
 		};
 	} // namespace detail

--- a/include/mpp/arithmetic/multiply.hpp
+++ b/include/mpp/arithmetic/multiply.hpp
@@ -34,16 +34,16 @@ namespace mpp
 {
 	namespace detail
 	{
-		inline constexpr auto mul_constant_op = [](const auto& left,
-													const auto& right,
-													std::size_t row_index,
-													std::size_t col_index) -> decltype(left(row_index, col_index) *
-																					   right) {
+		inline constexpr auto mul_constant_op =
+			[](const auto& left,
+				const auto& right,
+				std::size_t row_index,
+				std::size_t col_index) noexcept -> decltype(left(row_index, col_index) * right) {
 			return left(row_index, col_index) * right;
 		};
 
 		inline constexpr auto mul_op =
-			[](const auto& left, const auto& right, std::size_t row_index, std::size_t col_index) ->
+			[](const auto& left, const auto& right, std::size_t row_index, std::size_t col_index) noexcept ->
 			typename std::decay_t<decltype(left)>::value_type {
 				using value_type = typename std::decay_t<decltype(left)>::value_type;
 
@@ -61,7 +61,7 @@ namespace mpp
 
 	template<typename Base, typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent>
 	[[nodiscard]] inline auto operator*(const detail::expr_base<Base, Value, RowsExtent, ColumnsExtent>& obj,
-		Value constant) -> detail::expr_binary_constant_op<RowsExtent,
+		Value constant) noexcept -> detail::expr_binary_constant_op<RowsExtent,
 		ColumnsExtent,
 		detail::expr_base<Base, Value, RowsExtent, ColumnsExtent>,
 		Value,

--- a/include/mpp/arithmetic/subtract.hpp
+++ b/include/mpp/arithmetic/subtract.hpp
@@ -34,8 +34,8 @@ namespace mpp
 		inline constexpr auto sub_op = [](const auto& left,
 										   const auto& right,
 										   std::size_t row_index,
-										   std::size_t col_index) -> decltype(left(row_index, col_index) -
-																			  right(row_index, col_index)) {
+										   std::size_t col_index) noexcept -> decltype(left(row_index, col_index) -
+																					   right(row_index, col_index)) {
 			return left(row_index, col_index) - right(row_index, col_index);
 		};
 	} // namespace detail
@@ -49,7 +49,7 @@ namespace mpp
 		std::size_t RightColumnsExtent>
 	[[nodiscard]] inline auto operator-(
 		const detail::expr_base<LeftBase, Value, LeftRowsExtent, LeftColumnsExtent>& left,
-		const detail::expr_base<RightBase, Value, RightRowsExtent, RightColumnsExtent>& right)
+		const detail::expr_base<RightBase, Value, RightRowsExtent, RightColumnsExtent>& right) noexcept
 		-> detail::expr_binary_op<detail::prefer_static_extent(LeftRowsExtent, RightRowsExtent),
 			detail::prefer_static_extent(LeftColumnsExtent, RightColumnsExtent),
 			detail::expr_base<LeftBase, Value, LeftRowsExtent, LeftColumnsExtent>,

--- a/include/mpp/detail/expr/expr_base.hpp
+++ b/include/mpp/detail/expr/expr_base.hpp
@@ -31,12 +31,12 @@ namespace mpp::detail
 	class [[nodiscard]] expr_base
 	{
 	protected:
-		[[nodiscard]] constexpr auto expr_obj() const -> const Expr&
+		[[nodiscard]] constexpr auto expr_obj() const noexcept -> const Expr&
 		{
 			return static_cast<const Expr&>(*this);
 		}
 
-		[[nodiscard]] constexpr auto expr_mutable_obj() -> Expr&
+		[[nodiscard]] constexpr auto expr_mutable_obj() noexcept -> Expr&
 		{
 			return static_cast<Expr&>(*this);
 		}
@@ -44,22 +44,22 @@ namespace mpp::detail
 	public:
 		using value_type = Value;
 
-		[[nodiscard]] auto rows() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto rows() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return expr_obj().rows();
 		}
 
-		[[nodiscard]] auto columns() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto columns() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return expr_obj().columns();
 		}
 
-		[[nodiscard]] constexpr static auto rows_extent() -> std::size_t
+		[[nodiscard]] constexpr static auto rows_extent() noexcept -> std::size_t
 		{
 			return RowsExtent;
 		}
 
-		[[nodiscard]] constexpr static auto columns_extent() -> std::size_t
+		[[nodiscard]] constexpr static auto columns_extent() noexcept -> std::size_t
 		{
 			return ColumnsExtent;
 		}
@@ -74,7 +74,7 @@ namespace mpp::detail
 			return expr_obj().at(row_index, col_index);
 		}
 
-		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) const
+		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) const noexcept
 			-> value_type // @TODO: ISSUE #20
 		{
 			return expr_obj()(row_index, col_index);

--- a/include/mpp/detail/expr/expr_binary_constant_op.hpp
+++ b/include/mpp/detail/expr/expr_binary_constant_op.hpp
@@ -54,7 +54,7 @@ namespace mpp::detail
 			Value val,
 			std::size_t result_rows,
 			std::size_t result_columns,
-			const Op& op) // @TODO: ISSUE #20
+			const Op& op) noexcept // @TODO: ISSUE #20
 			:
 			obj_(obj),
 			val_(val),
@@ -64,12 +64,12 @@ namespace mpp::detail
 		{
 		}
 
-		[[nodiscard]] auto rows() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto rows() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return result_rows_;
 		}
 
-		[[nodiscard]] auto columns() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto columns() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return result_columns_;
 		}
@@ -84,7 +84,7 @@ namespace mpp::detail
 			return operator()(row_index, col_index);
 		}
 
-		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) const
+		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) const noexcept
 			-> value_type // @TODO: ISSUE #20
 		{
 			return op_(obj_, val_, row_index, col_index);

--- a/include/mpp/detail/expr/expr_binary_op.hpp
+++ b/include/mpp/detail/expr/expr_binary_op.hpp
@@ -54,7 +54,7 @@ namespace mpp::detail
 			const Right& right,
 			std::size_t result_rows,
 			std::size_t result_columns,
-			const Op& op) // @TODO: ISSUE #20
+			const Op& op) noexcept // @TODO: ISSUE #20
 			:
 			left_(left),
 			right_(right),
@@ -64,12 +64,12 @@ namespace mpp::detail
 		{
 		}
 
-		[[nodiscard]] auto rows() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto rows() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return result_rows_;
 		}
 
-		[[nodiscard]] auto columns() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto columns() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return result_columns_;
 		}
@@ -84,7 +84,7 @@ namespace mpp::detail
 			return operator()(row_index, col_index);
 		}
 
-		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) const
+		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) const noexcept
 			-> value_type // @TODO: ISSUE #20
 		{
 			return op_(left_, right_, row_index, col_index);

--- a/include/mpp/detail/matrix/matrix_base.hpp
+++ b/include/mpp/detail/matrix/matrix_base.hpp
@@ -390,8 +390,8 @@ namespace mpp::detail
 		using size_type              = std::size_t;
 
 		matrix_base(const matrix_base&) noexcept(
-			std::is_nothrow_copy_constructible_v<Value>)                              = default; // @TODO: ISSUE #20
-		matrix_base(matrix_base&&) noexcept(std::is_nothrow_move_assignable_v<Value>) = default; // @TODO: ISSUE #20
+			std::is_nothrow_copy_constructible_v<Value>)                                 = default; // @TODO: ISSUE #20
+		matrix_base(matrix_base&&) noexcept(std::is_nothrow_move_constructible_v<Value>) = default; // @TODO: ISSUE #20
 
 		auto operator       =(const matrix_base&) noexcept(std::is_nothrow_copy_assignable_v<Value>)
 			-> matrix_base& = default; // @TODO: ISSUE #20

--- a/include/mpp/detail/matrix/matrix_base.hpp
+++ b/include/mpp/detail/matrix/matrix_base.hpp
@@ -56,7 +56,8 @@ namespace mpp::detail
 		std::size_t columns_{ ColumnsExtent == dynamic ? std::size_t{} : ColumnsExtent };
 
 		template<typename... Args>
-		matrix_base(std::size_t rows, std::size_t columns, Args&&... args) :
+		matrix_base(std::size_t rows, std::size_t columns, Args&&... args) noexcept(
+			std::is_nothrow_constructible_v<Buffer, Args...>) :
 			buffer_(std::forward<Args>(args)...),
 			rows_{ rows },
 			columns_{ columns } // @TODO: ISSUE #20
@@ -388,98 +389,101 @@ namespace mpp::detail
 		using difference_type        = typename buffer_type::difference_type;
 		using size_type              = std::size_t;
 
-		matrix_base(const matrix_base&) = default; // @TODO: ISSUE #20
-		matrix_base(matrix_base&&)      = default; // @TODO: ISSUE #20
+		matrix_base(const matrix_base&) noexcept(
+			std::is_nothrow_copy_constructible_v<Value>)                              = default; // @TODO: ISSUE #20
+		matrix_base(matrix_base&&) noexcept(std::is_nothrow_move_assignable_v<Value>) = default; // @TODO: ISSUE #20
 
-		auto operator=(const matrix_base&) -> matrix_base& = default; // @TODO: ISSUE #20
-		auto operator=(matrix_base&&) -> matrix_base& = default;      // @TODO: ISSUE #20
+		auto operator       =(const matrix_base&) noexcept(std::is_nothrow_copy_assignable_v<Value>)
+			-> matrix_base& = default; // @TODO: ISSUE #20
+		auto operator       =(matrix_base&&) noexcept(std::is_nothrow_move_assignable_v<Value>)
+			-> matrix_base& = default; // @TODO: ISSUE #20
 
-		[[nodiscard]] auto data() -> pointer // @TODO: ISSUE #20
+		[[nodiscard]] auto data() noexcept -> pointer // @TODO: ISSUE #20
 		{
 			return buffer_.data();
 		}
 
-		[[nodiscard]] auto data() const -> const_pointer // @TODO: ISSUE #20
+		[[nodiscard]] auto data() const noexcept -> const_pointer // @TODO: ISSUE #20
 		{
 			return buffer_.data();
 		}
 
-		[[nodiscard]] auto begin() -> iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto begin() noexcept -> iterator // @TODO: ISSUE #20
 		{
 			return iterator(buffer_.begin(), columns_);
 		}
 
-		[[nodiscard]] auto begin() const -> const_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto begin() const noexcept -> const_iterator // @TODO: ISSUE #20
 		{
 			return const_iterator(buffer_.cbegin(), columns_);
 		}
 
-		[[nodiscard]] auto end() -> iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto end() noexcept -> iterator // @TODO: ISSUE #20
 		{
 			return iterator(buffer_.end(), columns_);
 		}
 
-		[[nodiscard]] auto end() const -> const_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto end() const noexcept -> const_iterator // @TODO: ISSUE #20
 		{
 			return const_iterator(buffer_.cend(), columns_);
 		}
 
-		[[nodiscard]] auto rbegin() -> reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto rbegin() noexcept -> reverse_iterator // @TODO: ISSUE #20
 		{
 			return reverse_iterator(buffer_.rbegin(), columns_);
 		}
 
-		[[nodiscard]] auto rbegin() const -> const_reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator // @TODO: ISSUE #20
 		{
 			return const_reverse_iterator(buffer_.crbegin(), columns_);
 		}
 
-		[[nodiscard]] auto rend() -> reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto rend() noexcept -> reverse_iterator // @TODO: ISSUE #20
 		{
 			return reverse_iterator(buffer_.rend(), columns_);
 		}
 
-		[[nodiscard]] auto rend() const -> const_reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto rend() const noexcept -> const_reverse_iterator // @TODO: ISSUE #20
 		{
 			return const_reverse_iterator(buffer_.crend(), columns_);
 		}
 
-		[[nodiscard]] auto cbegin() -> const_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto cbegin() noexcept -> const_iterator // @TODO: ISSUE #20
 		{
 			return const_iterator(buffer_.cbegin(), columns_);
 		}
 
-		[[nodiscard]] auto cbegin() const -> const_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto cbegin() const noexcept -> const_iterator // @TODO: ISSUE #20
 		{
 			return const_iterator(buffer_.cbegin(), columns_);
 		}
 
-		[[nodiscard]] auto cend() -> const_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto cend() noexcept -> const_iterator // @TODO: ISSUE #20
 		{
 			return const_iterator(buffer_.cend(), columns_);
 		}
 
-		[[nodiscard]] auto cend() const -> const_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto cend() const noexcept -> const_iterator // @TODO: ISSUE #20
 		{
 			return const_iterator(buffer_.cend(), columns_);
 		}
 
-		[[nodiscard]] auto crbegin() -> const_reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto crbegin() noexcept -> const_reverse_iterator // @TODO: ISSUE #20
 		{
 			return const_reverse_iterator(buffer_.crbegin(), columns_);
 		}
 
-		[[nodiscard]] auto crbegin() const -> const_reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator // @TODO: ISSUE #20
 		{
 			return const_reverse_iterator(buffer_.crbegin(), columns_);
 		}
 
-		[[nodiscard]] auto crend() -> const_reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto crend() noexcept -> const_reverse_iterator // @TODO: ISSUE #20
 		{
 			return const_reverse_iterator(buffer_.crend(), columns_);
 		}
 
-		[[nodiscard]] auto crend() const -> const_reverse_iterator // @TODO: ISSUE #20
+		[[nodiscard]] auto crend() const noexcept -> const_reverse_iterator // @TODO: ISSUE #20
 		{
 			return const_reverse_iterator(buffer_.crend(), columns_);
 		}
@@ -497,7 +501,8 @@ namespace mpp::detail
 			return operator()(row_index, column_index);
 		}
 
-		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) -> reference // @TODO: ISSUE #20
+		[[nodiscard]] auto operator()(std::size_t row_index, std::size_t col_index) noexcept
+			-> reference // @TODO: ISSUE #20
 		{
 			const auto index = index_2d_to_1d(columns_, row_index, col_index);
 
@@ -505,54 +510,54 @@ namespace mpp::detail
 		}
 
 		[[nodiscard]] auto operator()(std::size_t row_index,
-			std::size_t col_index) const -> const_reference // @TODO: ISSUE #20
+			std::size_t col_index) const noexcept -> const_reference // @TODO: ISSUE #20
 		{
 			const auto index = index_2d_to_1d(columns_, row_index, col_index);
 
 			return buffer_[index];
 		}
 
-		[[nodiscard]] auto rows() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto rows() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return rows_;
 		}
 
-		[[nodiscard]] auto columns() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto columns() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return columns_;
 		}
 
-		[[nodiscard]] auto front() -> reference // @TODO: ISSUE #20
+		[[nodiscard]] auto front() noexcept -> reference // @TODO: ISSUE #20
 		{
 			return buffer_.front();
 		}
 
-		[[nodiscard]] auto front() const -> const_reference // @TODO: ISSUE #20
+		[[nodiscard]] auto front() const noexcept -> const_reference // @TODO: ISSUE #20
 		{
 			return buffer_.front();
 		}
 
-		[[nodiscard]] auto back() -> reference // @TODO: ISSUE #20
+		[[nodiscard]] auto back() noexcept -> reference // @TODO: ISSUE #20
 		{
 			return buffer_.back();
 		}
 
-		[[nodiscard]] auto back() const -> const_reference // @TODO: ISSUE #20
+		[[nodiscard]] auto back() const noexcept -> const_reference // @TODO: ISSUE #20
 		{
 			return buffer_.back();
 		}
 
-		[[nodiscard]] auto size() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto size() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return buffer_.size();
 		}
 
-		[[nodiscard]] auto max_size() const -> std::size_t // @TODO: ISSUE #20
+		[[nodiscard]] auto max_size() const noexcept -> std::size_t // @TODO: ISSUE #20
 		{
 			return buffer_.max_size();
 		}
 
-		[[nodiscard]] auto empty() const -> bool // @TODO: ISSUE #20
+		[[nodiscard]] auto empty() const noexcept -> bool // @TODO: ISSUE #20
 		{
 			return buffer_.empty();
 		}
@@ -564,7 +569,7 @@ namespace mpp::detail
 			return *this;
 		}
 
-		void swap(matrix_base& right) // @TODO: ISSUE #20
+		void swap(matrix_base& right) noexcept // @TODO: ISSUE #20
 		{
 			// Don't swap with the same object
 			if (&right != this)
@@ -637,12 +642,12 @@ namespace mpp::detail
 
 		using base::operator=;
 
-		[[nodiscard]] auto get_allocator() const -> allocator_type // @TODO: ISSUE #20
+		[[nodiscard]] auto get_allocator() const noexcept -> allocator_type // @TODO: ISSUE #20
 		{
 			return base::buffer_.get_allocator();
 		}
 
-		void clear() // @TODO: ISSUE #20
+		void clear() noexcept // @TODO: ISSUE #20
 		{
 			base::rows_    = 0;
 			base::columns_ = 0;

--- a/include/mpp/detail/matrix/matrix_iterator.hpp
+++ b/include/mpp/detail/matrix/matrix_iterator.hpp
@@ -46,13 +46,14 @@ namespace mpp::detail
 		using iterator_category = std::contiguous_iterator_tag; // STL doesn't use contiguous iterator tag explicitly,
 																// but we do meet its requirements
 
-		explicit matrix_iterator(Iterator current, std::size_t columns) :
+		explicit matrix_iterator(Iterator current, std::size_t columns) noexcept(
+			std::is_nothrow_copy_constructible_v<Iterator>) :
 			current_(current),
 			columns_(columns) // @TODO: ISSUE #20
 		{
 		}
 
-		matrix_iterator() = default; // @TODO: ISSUE #20
+		matrix_iterator() noexcept(std::is_nothrow_default_constructible_v<Iterator>) = default; // @TODO: ISSUE #20
 
 		[[nodiscard]] auto operator*() -> reference // @TODO: ISSUE #20
 		{
@@ -64,13 +65,13 @@ namespace mpp::detail
 			return *current_;
 		}
 
-		auto operator++() -> matrix_iterator& // @TODO: ISSUE #20
+		auto operator++() noexcept -> matrix_iterator& // @TODO: ISSUE #20
 		{
 			++current_;
 			return *this;
 		}
 
-		auto operator++(int) -> matrix_iterator // @TODO: ISSUE #20
+		auto operator++(int) noexcept -> matrix_iterator // @TODO: ISSUE #20
 		{
 			auto old = matrix_iterator<Iterator>(current_, columns_);
 
@@ -78,7 +79,7 @@ namespace mpp::detail
 			return old;
 		}
 
-		auto operator+=(difference_type n) -> matrix_iterator& // @TODO: ISSUE #20
+		auto operator+=(difference_type n) noexcept -> matrix_iterator& // @TODO: ISSUE #20
 		{
 			current_ += n;
 			return *this;
@@ -151,7 +152,8 @@ namespace mpp::detail
 		[[nodiscard]] auto operator!=(const matrix_iterator&) const -> bool                  = default;
 		[[nodiscard]] auto operator<=>(const matrix_iterator&) const -> std::strong_ordering = default;
 
-		friend inline void swap(matrix_iterator<Iterator>& left, matrix_iterator<Iterator> right) // @TODO: ISSUE #20
+		friend inline void swap(matrix_iterator<Iterator>& left,
+			matrix_iterator<Iterator> right) noexcept // @TODO: ISSUE #20
 		{
 			using std::swap;
 

--- a/include/mpp/detail/utility/algorithm_helpers.hpp
+++ b/include/mpp/detail/utility/algorithm_helpers.hpp
@@ -31,7 +31,8 @@
 
 namespace mpp::detail
 {
-	[[nodiscard]] constexpr auto prefer_static_extent(std::size_t left_extent, std::size_t right_extent) -> std::size_t
+	[[nodiscard]] constexpr auto prefer_static_extent(std::size_t left_extent, std::size_t right_extent) noexcept
+		-> std::size_t
 	{
 		if (left_extent != dynamic || right_extent != dynamic)
 		{
@@ -106,6 +107,6 @@ namespace mpp::detail
 			}
 		}
 
-		return static_cast<To>(std::round(det));
+		return static_cast<To>(det);
 	}
 } // namespace mpp::detail

--- a/include/mpp/detail/utility/cpo_base.hpp
+++ b/include/mpp/detail/utility/cpo_base.hpp
@@ -27,7 +27,9 @@ namespace mpp::detail
 	struct cpo_base
 	{
 		template<typename... Args>
-		[[nodiscard]] auto operator()(Args&&... args) const -> tag_invoke_result_t<CPO, Args...> // @TODO: ISSUE #20
+		[[nodiscard]] auto operator()(Args&&... args) const
+			noexcept(noexcept(tag_invoke_cpo(CPO{}, std::forward<Args>(args)...)))
+				-> tag_invoke_result_t<CPO, Args...> // @TODO: ISSUE #20
 		{
 			// Practically empty CPO objects gets optimized out, so it's okay to create it to help overload resolution
 			return tag_invoke_cpo(CPO{}, std::forward<Args>(args)...);

--- a/include/mpp/detail/utility/tag_invoke.hpp
+++ b/include/mpp/detail/utility/tag_invoke.hpp
@@ -32,7 +32,8 @@ namespace mpp::detail
 	{
 		template<typename CPO, typename... Args>
 		[[nodiscard]] auto operator()(CPO&& cpo, Args&&... args) const
-			-> tag_invoke_result_t<CPO, Args...> // @TODO: ISSUE #20
+			noexcept(noexcept(tag_invoke(std::forward<CPO>(cpo), std::forward<Args>(args)...)))
+				-> tag_invoke_result_t<CPO, Args...> // @TODO: ISSUE #20
 		{
 			return tag_invoke(std::forward<CPO>(cpo), std::forward<Args>(args)...);
 		}

--- a/include/mpp/detail/utility/utility.hpp
+++ b/include/mpp/detail/utility/utility.hpp
@@ -25,8 +25,8 @@
 
 namespace mpp::detail
 {
-	[[nodiscard]] constexpr auto index_2d_to_1d(std::size_t columns, std::size_t row_index, std::size_t column_index)
-		-> std::size_t
+	[[nodiscard]] constexpr auto
+	index_2d_to_1d(std::size_t columns, std::size_t row_index, std::size_t column_index) noexcept -> std::size_t
 	{
 		// This is mainly for avoiding bug-prone code, because this calculation occurs in a lot of places, and a typo
 		// can cause a lot of things to fail. It's safer to wrap this calculation in a function, so the bug is easier to

--- a/include/mpp/matrix/dynamic_columns.hpp
+++ b/include/mpp/matrix/dynamic_columns.hpp
@@ -50,9 +50,9 @@ namespace mpp
 	public:
 		using base::operator=;
 
-		matrix() : base(RowsExtent, 0, Allocator{}) {} // @TODO: ISSUE #20
+		matrix() noexcept(noexcept(Allocator())) : base(RowsExtent, 0, Allocator{}) {} // @TODO: ISSUE #20
 
-		explicit matrix(const Allocator& allocator) : base(RowsExtent, 0, allocator) {} // @TODO: ISSUE #20
+		explicit matrix(const Allocator& allocator) noexcept : base(RowsExtent, 0, allocator) {} // @TODO: ISSUE #20
 
 		matrix(const matrix& right, const Allocator& allocator) :
 			base(right.rows_, right.columns_, right.buffer_, allocator) // @TODO: ISSUE #20

--- a/include/mpp/matrix/dynamic_rows.hpp
+++ b/include/mpp/matrix/dynamic_rows.hpp
@@ -50,9 +50,9 @@ namespace mpp
 	public:
 		using base::operator=;
 
-		matrix() : base(0, ColumnsExtent, Allocator{}) {} // @TODO: ISSUE #20
+		matrix() noexcept(noexcept(Allocator())) : base(0, ColumnsExtent, Allocator{}) {} // @TODO: ISSUE #20
 
-		explicit matrix(const Allocator& allocator) : base(0, ColumnsExtent, allocator) {} // @TODO: ISSUE #20
+		explicit matrix(const Allocator& allocator) noexcept : base(0, ColumnsExtent, allocator) {} // @TODO: ISSUE #20
 
 		matrix(const matrix& right, const Allocator& allocator) :
 			base(right.rows_, right.columns_, right.buffer_, allocator) // @TODO: ISSUE #20

--- a/include/mpp/matrix/fully_dynamic.hpp
+++ b/include/mpp/matrix/fully_dynamic.hpp
@@ -50,9 +50,9 @@ namespace mpp
 	public:
 		using base::operator=;
 
-		matrix() : base(0, 0, Allocator{}) {} // @TODO: ISSUE #20
+		matrix() noexcept(noexcept(Allocator())) : base(0, 0, Allocator{}) {} // @TODO: ISSUE #20
 
-		explicit matrix(const Allocator& allocator) : base(0, 0, allocator) {} // @TODO: ISSUE #20
+		explicit matrix(const Allocator& allocator) noexcept : base(0, 0, allocator) {} // @TODO: ISSUE #20
 
 		matrix(const matrix& right, const Allocator& allocator) :
 			base(right.rows_, right.columns_, right.buffer_, allocator) // @TODO: ISSUE #20

--- a/include/mpp/utility.hpp
+++ b/include/mpp/utility.hpp
@@ -19,10 +19,11 @@
 
 #pragma once
 
-// Don't include config_extents.hpp because that is only for user customizations
+// Don't include configuration.hpp because that is only for user customizations
 
 #include <mpp/utility/comparison.hpp>
 #include <mpp/utility/print.hpp>
 #include <mpp/utility/singular.hpp>
 #include <mpp/utility/square.hpp>
+#include <mpp/utility/traits.hpp>
 #include <mpp/utility/type.hpp>

--- a/include/mpp/utility/comparison.hpp
+++ b/include/mpp/utility/comparison.hpp
@@ -44,7 +44,10 @@ namespace mpp
 			const matrix<LeftValue, LeftRowsExtent, LeftColumnsExtent, LeftAllocator>& left,
 			const matrix<RightValue, RightRowsExtent, RightColumnsExtent, RightAllocator>& right,
 			bool compare_rows,
-			bool compare_columns) -> std::pair<std::partial_ordering, std::partial_ordering> // @TODO: ISSUE #20
+			bool compare_columns) noexcept(noexcept(std::pair{
+			compare_rows ? left.rows() <=> right.rows() : std::partial_ordering::unordered,
+			compare_columns ? left.columns() <=> right.columns() : std::partial_ordering::unordered }))
+			-> std::pair<std::partial_ordering, std::partial_ordering> // @TODO: ISSUE #20
 		{
 			return std::pair{ compare_rows ? left.rows() <=> right.rows() : std::partial_ordering::unordered,
 				compare_columns ? left.columns() <=> right.columns() : std::partial_ordering::unordered };
@@ -65,7 +68,12 @@ namespace mpp
 		[[nodiscard]] friend inline auto tag_invoke(elements_compare_t,
 			const matrix<LeftValue, LeftRowsExtent, LeftColumnsExtent, LeftAllocator>& left,
 			const matrix<RightValue, RightRowsExtent, RightColumnsExtent, RightAllocator>& right,
-			CompareThreeway compare_three_way_fn = {}) // @TODO: ISSUE #20
+			CompareThreeway
+				compare_three_way_fn = {}) noexcept(noexcept(std::lexicographical_compare_three_way(left.begin(),
+			left.end(),
+			right.begin(),
+			right.end(),
+			compare_three_way_fn))) // @TODO: ISSUE #20
 		{
 			return std::lexicographical_compare_three_way(left.begin(),
 				left.end(),
@@ -85,7 +93,7 @@ namespace mpp
 	namespace detail
 	{
 		template<typename T>
-		constexpr auto constexpr_abs(T t) -> T
+		constexpr auto constexpr_abs(T t) noexcept -> T
 		{
 			if (std::is_constant_evaluated())
 			{
@@ -96,8 +104,8 @@ namespace mpp
 		}
 	} // namespace detail
 
-	inline constexpr auto floating_point_compare = []<typename T, typename U>(const T& left,
-													   const U& right) -> std::compare_three_way_result_t<T, U> {
+	inline constexpr auto floating_point_compare =
+		[]<typename T, typename U>(const T& left, const U& right) noexcept -> std::compare_three_way_result_t<T, U> {
 		using common_type   = std::common_type_t<T, U>;
 		using ordering_type = std::compare_three_way_result_t<common_type, common_type>;
 

--- a/include/mpp/utility/comparison.hpp
+++ b/include/mpp/utility/comparison.hpp
@@ -68,14 +68,16 @@ namespace mpp
 		[[nodiscard]] friend inline auto tag_invoke(elements_compare_t,
 			const matrix<LeftValue, LeftRowsExtent, LeftColumnsExtent, LeftAllocator>& left,
 			const matrix<RightValue, RightRowsExtent, RightColumnsExtent, RightAllocator>& right,
-			CompareThreeway compare_three_way_fn = {})
-#ifndef __clang__ // Testing if Clang crashes with this noexcept specification
+			CompareThreeway compare_three_way_fn = {}) // @TODO: ISSUE #20
+#if defined(__clang__) && __clang_major__ > 11
+			// Clang 11 and below crashes if this function had any noexcept specification
+			// @NOTE: It's fixed with Clang 12+
 			noexcept(noexcept(std::lexicographical_compare_three_way(left.begin(),
 				left.end(),
 				right.begin(),
 				right.end(),
 				compare_three_way_fn)))
-#endif // @TODO: ISSUE #20
+#endif
 		{
 			return std::lexicographical_compare_three_way(left.begin(),
 				left.end(),

--- a/include/mpp/utility/comparison.hpp
+++ b/include/mpp/utility/comparison.hpp
@@ -68,12 +68,14 @@ namespace mpp
 		[[nodiscard]] friend inline auto tag_invoke(elements_compare_t,
 			const matrix<LeftValue, LeftRowsExtent, LeftColumnsExtent, LeftAllocator>& left,
 			const matrix<RightValue, RightRowsExtent, RightColumnsExtent, RightAllocator>& right,
-			CompareThreeway
-				compare_three_way_fn = {}) noexcept(noexcept(std::lexicographical_compare_three_way(left.begin(),
-			left.end(),
-			right.begin(),
-			right.end(),
-			compare_three_way_fn))) // @TODO: ISSUE #20
+			CompareThreeway compare_three_way_fn = {})
+#ifndef __clang__ // Testing if Clang crashes with this noexcept specification
+			noexcept(noexcept(std::lexicographical_compare_three_way(left.begin(),
+				left.end(),
+				right.begin(),
+				right.end(),
+				compare_three_way_fn)))
+#endif // @TODO: ISSUE #20
 		{
 			return std::lexicographical_compare_three_way(left.begin(),
 				left.end(),

--- a/include/mpp/utility/square.hpp
+++ b/include/mpp/utility/square.hpp
@@ -30,7 +30,7 @@ namespace mpp
 	{
 		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent, typename Allocator>
 		[[nodiscard]] friend inline auto tag_invoke(square_t,
-			const matrix<Value, RowsExtent, ColumnsExtent, Allocator>& obj) -> bool // @TODO: ISSUE #20
+			const matrix<Value, RowsExtent, ColumnsExtent, Allocator>& obj) noexcept -> bool // @TODO: ISSUE #20
 		{
 			return obj.rows() == obj.columns();
 		}

--- a/include/mpp/utility/type.hpp
+++ b/include/mpp/utility/type.hpp
@@ -39,7 +39,7 @@ namespace mpp
 	{
 		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent, typename Allocator>
 		[[nodiscard]] friend inline auto tag_invoke(type_t,
-			const matrix<Value, RowsExtent, ColumnsExtent, Allocator>& obj) -> matrix_type // @TODO: ISSUE #20
+			const matrix<Value, RowsExtent, ColumnsExtent, Allocator>& obj) noexcept -> matrix_type // @TODO: ISSUE #20
 		{
 			auto row_is_dynamic    = obj.rows_extent() == dynamic;
 			auto column_is_dynamic = obj.columns_extent() == dynamic;


### PR DESCRIPTION
Drive-by:
- [x] Rename `config_extents.hpp` to `configuration.hpp` in `<mpp/utility.hpp>`
- [x] Include `<mpp/utility/traits.hpp>` in `<mpp/utility.hpp>`
- [x] Revert build tests in Release (Fixes #276)

Other potential candidates were not marked for sake of simplicity and sanity.