### PR TITLE
Allow customizing buffer types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ A C++20 and later matrix library
 
 * GCC 10
 * Clang 11 with libstdc++ (Clang 11 has a ICE for noexcept specification for `mpp::elements_compare`, so the noexcept specification doesn't exist for that CPO for Clang 11)
+  + NOTE: **Only works on Windows**, as Linux builds fail with this error (I haven't figured out how to fix this error):
+
+``` txt
+/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:3392:19: error: missing 'typename' prior to dependent type name 'iterator_traits<iterator_t<_Base>>::iterator_category'
+```
+
 * MSVC 19.28
 
 ## How to Include:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ Customizations of options that affect the library globally can be changed via sp
 ``` cpp
 #include <mpp/utility/configuration.hpp>
 
+#include <array>
+#include <vector>
+
 namespace mpp
 {
   template<>
@@ -204,6 +207,22 @@ namespace mpp
     static constexpr std::size_t columns_extent = 10;
 
     static constexpr bool use_unsafe = true;
+
+    /**
+     * These are the default buffer type aliases the library will use, but you can customize them
+     */
+
+    template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent, typename>
+		using static_buffer = std::array<Value, RowsExtent * ColumnsExtent>; // mpp::matrix<int, 1, 2>
+
+		template<typename Value, std::size_t, std::size_t, typename Alloc>
+		using dynamic_buffer = std::vector<Value, Alloc>; // mpp::matrix<int>
+
+		template<typename Value, std::size_t, std::size_t ColumnsExtent, typename Alloc>
+		using dynamic_rows_buffer = dynamic_buffer<Value, 1, ColumnsExtent, Alloc>; // mpp::matrix<int, mpp::dynamic, 2>
+
+		template<typename Value, std::size_t RowsExtent, std::size_t, typename Alloc>
+		using dynamic_columns_buffer = dynamic_buffer<Value, RowsExtent, 1, Alloc>; // mpp::matrix<int, 1, mpp::dynamic>
   };
 } // namespace mpp
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,9 +25,8 @@ jobs:
     steps:
       - checkout: self
 
-      # @TODO: Don't install release candidate once LLVM 12 officially releases
       - script: |
-          pip3 install lit==12.0.0rc1 --no-warn-script-location
+          pip3 install lit==12.0.0 --no-warn-script-location
           echo '##vso[task.prependpath]$(HOME)/.local/bin'
         displayName: Install Python LLVM Lit
 
@@ -57,9 +56,8 @@ jobs:
     steps:
       - checkout: self
 
-      # @TODO: Don't install release candidate once LLVM 12 officially releases
       - script: |
-          pip3 install lit==12.0.0rc1 --no-warn-script-location
+          pip3 install lit==12.0.0 --no-warn-script-location
           echo '##vso[task.prependpath]$(HOME)/.local/bin'
         displayName: Install Python LLVM Lit
 
@@ -90,9 +88,8 @@ jobs:
     steps:
       - checkout: self
 
-      # @TODO: Don't install release candidate once LLVM 12 officially releases
       - script: |
-          pip3 install lit==12.0.0rc1 --no-warn-script-location
+          pip3 install lit==12.0.0 --no-warn-script-location
           echo '##vso[task.prependpath]$(HOME)/.local/bin'
         displayName: Install Python LLVM Lit
 
@@ -121,9 +118,8 @@ jobs:
     steps:
       - checkout: self
 
-      # @TODO: Don't install release candidate once LLVM 12 officially releases
       - script: |
-          pip install lit==12.0.0rc1 --no-warn-script-location
+          pip install lit==12.0.0 --no-warn-script-location
           echo '##vso[task.prependpath]$(HOME)/.local/bin'
         displayName: Install Python LLVM Lit
 
@@ -154,9 +150,8 @@ jobs:
     steps:
       - checkout: self
 
-      # @TODO: Don't install release candidate once LLVM 12 officially releases
       - script: |
-          pip install lit==12.0.0rc1 --no-warn-script-location
+          pip install lit==12.0.0 --no-warn-script-location
           echo '##vso[task.prependpath]$(HOME)/.local/bin'
         displayName: Install Python LLVM Lit
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,7 @@ jobs:
 
   - job: UbuntuClang
     displayName: Ubuntu Clang 11
+    # @TODO: Allow this when the bug is somehow identified...
     condition: false
 
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,7 @@ jobs:
 
   - job: UbuntuClang
     displayName: Ubuntu Clang 11
+    condition: false
 
     pool:
       vmImage: ubuntu-latest

--- a/external/tests/src/customization.cpp
+++ b/external/tests/src/customization.cpp
@@ -19,6 +19,9 @@
 
 #include <mpp/utility/configuration.hpp>
 
+#include <array>
+#include <vector>
+
 namespace mpp
 {
 	template<>
@@ -31,6 +34,18 @@ namespace mpp
 		static constexpr std::size_t columns_extent = 10;
 
 		static constexpr bool use_unsafe = true;
+
+		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent>
+		using static_buffer = std::array<Value, RowsExtent * ColumnsExtent>;
+
+		template<typename Value, std::size_t, std::size_t>
+		using dynamic_buffer = std::vector<Value>;
+
+		template<typename Value, std::size_t, std::size_t ColumnsExtent>
+		using dynamic_rows_buffer = dynamic_buffer<Value, 1, ColumnsExtent>;
+
+		template<typename Value, std::size_t RowsExtent, std::size_t>
+		using dynamic_columns_buffer = dynamic_buffer<Value, RowsExtent, 1>;
 	};
 } // namespace mpp
 

--- a/external/tests/src/customization.cpp
+++ b/external/tests/src/customization.cpp
@@ -35,17 +35,17 @@ namespace mpp
 
 		static constexpr bool use_unsafe = true;
 
-		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent>
+		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent, typename>
 		using static_buffer = std::array<Value, RowsExtent * ColumnsExtent>;
 
-		template<typename Value, std::size_t, std::size_t>
-		using dynamic_buffer = std::vector<Value>;
+		template<typename Value, std::size_t, std::size_t, typename Alloc>
+		using dynamic_buffer = std::vector<Value, Alloc>;
 
-		template<typename Value, std::size_t, std::size_t ColumnsExtent>
-		using dynamic_rows_buffer = dynamic_buffer<Value, 1, ColumnsExtent>;
+		template<typename Value, std::size_t, std::size_t ColumnsExtent, typename Alloc>
+		using dynamic_rows_buffer = dynamic_buffer<Value, 1, ColumnsExtent, Alloc>;
 
-		template<typename Value, std::size_t RowsExtent, std::size_t>
-		using dynamic_columns_buffer = dynamic_buffer<Value, RowsExtent, 1>;
+		template<typename Value, std::size_t RowsExtent, std::size_t, typename Alloc>
+		using dynamic_columns_buffer = dynamic_buffer<Value, RowsExtent, 1, Alloc>;
 	};
 } // namespace mpp
 

--- a/external/thirdparty/boost/ut.hpp
+++ b/external/thirdparty/boost/ut.hpp
@@ -5,7 +5,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#if defined(__cpp_modules)
+#if 0 // defined(__cpp_modules)
 export module boost.ut;
 export import std;
 #else
@@ -83,7 +83,7 @@ auto operator>=(TLhs, TRhs) -> bool;
 #endif
 #endif
 
-#if defined(__cpp_modules)
+#if 0 // defined(__cpp_modules)
 export namespace boost::inline ext::ut {
 #else
 namespace boost {
@@ -2555,7 +2555,7 @@ template <bool Constant>
   using operators::operator>>;
   }  // namespace v1_1_8
 }  // namespace ut
-#if !defined(__cpp_modules)
+#if 1 // !defined(__cpp_modules)
 }  // namespace inline ext
 }  // namespace boost
 #endif

--- a/include/mpp/detail/matrix/matrix_base.hpp
+++ b/include/mpp/detail/matrix/matrix_base.hpp
@@ -598,6 +598,7 @@ namespace mpp::detail
 		using base = matrix_base<Derived, Buffer, Value, RowsExtent, ColumnsExtent, Allocator>;
 
 	protected:
+		// @FIXME: Add noexcept specification here
 		template<typename... Args>
 		matrix_dynamic_base(std::size_t rows, std::size_t columns, Args&&... args) :
 			base(rows, columns, std::forward<Args>(args)...)

--- a/include/mpp/matrix/dynamic_columns.hpp
+++ b/include/mpp/matrix/dynamic_columns.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t RowsExtent, typename Allocator>
 	class matrix<Value, RowsExtent, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
+			typename configuration<override>::template dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
 			Value,
 			RowsExtent,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
+			typename configuration<override>::template dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
 			Value,
 			RowsExtent,
 			dynamic,

--- a/include/mpp/matrix/dynamic_columns.hpp
+++ b/include/mpp/matrix/dynamic_columns.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t RowsExtent, typename Allocator>
 	class matrix<Value, RowsExtent, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			std::vector<Value, Allocator>,
+			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1>,
 			Value,
 			RowsExtent,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			std::vector<Value, Allocator>,
+			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1>,
 			Value,
 			RowsExtent,
 			dynamic,

--- a/include/mpp/matrix/dynamic_columns.hpp
+++ b/include/mpp/matrix/dynamic_columns.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t RowsExtent, typename Allocator>
 	class matrix<Value, RowsExtent, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			typename configuration<override>::template dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
+			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
 			Value,
 			RowsExtent,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			typename configuration<override>::template dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
+			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
 			Value,
 			RowsExtent,
 			dynamic,

--- a/include/mpp/matrix/dynamic_columns.hpp
+++ b/include/mpp/matrix/dynamic_columns.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t RowsExtent, typename Allocator>
 	class matrix<Value, RowsExtent, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1>,
+			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
 			Value,
 			RowsExtent,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, RowsExtent, dynamic, Allocator>,
-			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1>,
+			typename configuration<override>::dynamic_columns_buffer<Value, RowsExtent, 1, Allocator>,
 			Value,
 			RowsExtent,
 			dynamic,

--- a/include/mpp/matrix/dynamic_rows.hpp
+++ b/include/mpp/matrix/dynamic_rows.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t ColumnsExtent, typename Allocator>
 	class matrix<Value, dynamic, ColumnsExtent, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent>,
+			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
 			Value,
 			dynamic,
 			ColumnsExtent,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent>,
+			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
 			Value,
 			dynamic,
 			ColumnsExtent,

--- a/include/mpp/matrix/dynamic_rows.hpp
+++ b/include/mpp/matrix/dynamic_rows.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t ColumnsExtent, typename Allocator>
 	class matrix<Value, dynamic, ColumnsExtent, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
+			typename configuration<override>::template dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
 			Value,
 			dynamic,
 			ColumnsExtent,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
+			typename configuration<override>::template dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
 			Value,
 			dynamic,
 			ColumnsExtent,

--- a/include/mpp/matrix/dynamic_rows.hpp
+++ b/include/mpp/matrix/dynamic_rows.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t ColumnsExtent, typename Allocator>
 	class matrix<Value, dynamic, ColumnsExtent, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			std::vector<Value, Allocator>,
+			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent>,
 			Value,
 			dynamic,
 			ColumnsExtent,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			std::vector<Value, Allocator>,
+			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent>,
 			Value,
 			dynamic,
 			ColumnsExtent,

--- a/include/mpp/matrix/dynamic_rows.hpp
+++ b/include/mpp/matrix/dynamic_rows.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t ColumnsExtent, typename Allocator>
 	class matrix<Value, dynamic, ColumnsExtent, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			typename configuration<override>::template dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
+			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
 			Value,
 			dynamic,
 			ColumnsExtent,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, ColumnsExtent, Allocator>,
-			typename configuration<override>::template dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
+			typename configuration<override>::dynamic_rows_buffer<Value, 1, ColumnsExtent, Allocator>,
 			Value,
 			dynamic,
 			ColumnsExtent,

--- a/include/mpp/matrix/fully_dynamic.hpp
+++ b/include/mpp/matrix/fully_dynamic.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, typename Allocator>
 	class matrix<Value, dynamic, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			typename configuration<override>::template dynamic_buffer<Value, dynamic, dynamic, Allocator>,
+			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic, Allocator>,
 			Value,
 			dynamic,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			typename configuration<override>::template dynamic_buffer<Value, dynamic, dynamic, Allocator>,
+			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic, Allocator>,
 			Value,
 			dynamic,
 			dynamic,

--- a/include/mpp/matrix/fully_dynamic.hpp
+++ b/include/mpp/matrix/fully_dynamic.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, typename Allocator>
 	class matrix<Value, dynamic, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			std::vector<Value, Allocator>,
+			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic>,
 			Value,
 			dynamic,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			std::vector<Value, Allocator>,
+			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic>,
 			Value,
 			dynamic,
 			dynamic,

--- a/include/mpp/matrix/fully_dynamic.hpp
+++ b/include/mpp/matrix/fully_dynamic.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, typename Allocator>
 	class matrix<Value, dynamic, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic>,
+			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic, Allocator>,
 			Value,
 			dynamic,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic>,
+			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic, Allocator>,
 			Value,
 			dynamic,
 			dynamic,

--- a/include/mpp/matrix/fully_dynamic.hpp
+++ b/include/mpp/matrix/fully_dynamic.hpp
@@ -34,14 +34,14 @@ namespace mpp
 	template<detail::arithmetic Value, typename Allocator>
 	class matrix<Value, dynamic, dynamic, Allocator> :
 		public detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic, Allocator>,
+			typename configuration<override>::template dynamic_buffer<Value, dynamic, dynamic, Allocator>,
 			Value,
 			dynamic,
 			dynamic,
 			Allocator>
 	{
 		using base = detail::matrix_dynamic_base<matrix<Value, dynamic, dynamic, Allocator>,
-			typename configuration<override>::dynamic_buffer<Value, dynamic, dynamic, Allocator>,
+			typename configuration<override>::template dynamic_buffer<Value, dynamic, dynamic, Allocator>,
 			Value,
 			dynamic,
 			dynamic,

--- a/include/mpp/matrix/fully_static.hpp
+++ b/include/mpp/matrix/fully_static.hpp
@@ -38,14 +38,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t RowsExtent, std::size_t ColumnsExtent, typename Allocator>
 	class matrix :
 		public detail::matrix_base<matrix<Value, RowsExtent, ColumnsExtent, Allocator>,
-			typename configuration<override>::static_buffer<Value, RowsExtent, ColumnsExtent>,
+			typename configuration<override>::static_buffer<Value, RowsExtent, ColumnsExtent, Allocator>,
 			Value,
 			RowsExtent,
 			ColumnsExtent,
 			Allocator>
 	{
 		using base = detail::matrix_base<matrix<Value, RowsExtent, ColumnsExtent, Allocator>,
-			typename configuration<override>::static_buffer<Value, RowsExtent, ColumnsExtent>,
+			typename configuration<override>::static_buffer<Value, RowsExtent, ColumnsExtent, Allocator>,
 			Value,
 			RowsExtent,
 			ColumnsExtent,

--- a/include/mpp/matrix/fully_static.hpp
+++ b/include/mpp/matrix/fully_static.hpp
@@ -38,14 +38,14 @@ namespace mpp
 	template<detail::arithmetic Value, std::size_t RowsExtent, std::size_t ColumnsExtent, typename Allocator>
 	class matrix :
 		public detail::matrix_base<matrix<Value, RowsExtent, ColumnsExtent, Allocator>,
-			std::array<Value, RowsExtent * ColumnsExtent>,
+			typename configuration<override>::static_buffer<Value, RowsExtent, ColumnsExtent>,
 			Value,
 			RowsExtent,
 			ColumnsExtent,
 			Allocator>
 	{
 		using base = detail::matrix_base<matrix<Value, RowsExtent, ColumnsExtent, Allocator>,
-			std::array<Value, RowsExtent * ColumnsExtent>,
+			typename configuration<override>::static_buffer<Value, RowsExtent, ColumnsExtent>,
 			Value,
 			RowsExtent,
 			ColumnsExtent,

--- a/include/mpp/utility/configuration.hpp
+++ b/include/mpp/utility/configuration.hpp
@@ -45,16 +45,16 @@ namespace mpp
 
 		static constexpr auto use_unsafe = false;
 
-		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent>
+		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent, typename>
 		using static_buffer = std::array<Value, RowsExtent * ColumnsExtent>;
 
-		template<typename Value, std::size_t, std::size_t>
-		using dynamic_buffer = std::vector<Value>;
+		template<typename Value, std::size_t, std::size_t, typename Alloc>
+		using dynamic_buffer = std::vector<Value, Alloc>;
 
-		template<typename Value, std::size_t, std::size_t ColumnsExtent>
-		using dynamic_rows_buffer = dynamic_buffer<Value, 1, ColumnsExtent>;
+		template<typename Value, std::size_t, std::size_t ColumnsExtent, typename Alloc>
+		using dynamic_rows_buffer = dynamic_buffer<Value, 1, ColumnsExtent, Alloc>;
 
-		template<typename Value, std::size_t RowsExtent, std::size_t>
-		using dynamic_columns_buffer = dynamic_buffer<Value, RowsExtent, 1>;
+		template<typename Value, std::size_t RowsExtent, std::size_t, typename Alloc>
+		using dynamic_columns_buffer = dynamic_buffer<Value, RowsExtent, 1, Alloc>;
 	};
 } // namespace mpp

--- a/include/mpp/utility/configuration.hpp
+++ b/include/mpp/utility/configuration.hpp
@@ -22,8 +22,10 @@
 // @TODO: Export std::allocator for modules
 #include <mpp/detail/utility/public.hpp>
 
+#include <array>
 #include <cstddef>
 #include <memory>
+#include <vector>
 
 namespace mpp
 {
@@ -42,5 +44,17 @@ namespace mpp
 		static constexpr auto columns_extent = dynamic;
 
 		static constexpr auto use_unsafe = false;
+
+		template<typename Value, std::size_t RowsExtent, std::size_t ColumnsExtent>
+		using static_buffer = std::array<Value, RowsExtent * ColumnsExtent>;
+
+		template<typename Value, std::size_t, std::size_t>
+		using dynamic_buffer = std::vector<Value>;
+
+		template<typename Value, std::size_t, std::size_t ColumnsExtent>
+		using dynamic_rows_buffer = dynamic_buffer<Value, 1, ColumnsExtent>;
+
+		template<typename Value, std::size_t RowsExtent, std::size_t>
+		using dynamic_columns_buffer = dynamic_buffer<Value, RowsExtent, 1>;
 	};
 } // namespace mpp


### PR DESCRIPTION
Fixes #294

Drive-by:
- [x] Disable Clang 11 due to error "expected typename prior to dependent typename" (Linux only)
- [x] Disable modules in ut.hpp due to VS 16.10p3 emitting errors with it (it is implicitly enabled via `/std:c++latest`)
- [x] Fix comment "install lit 12 release candidate" to target lit 13 in `azure_pipelines.yml` and install lit 12
- [x] Cross out "Clang 11 w/ libstdc++" and make it say Windows only