### PR TITLE
Re-enable Ubuntu Clang 11 in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ A C++20 and later matrix library
 
 * GCC 10
 * Clang 11 with libstdc++ (Clang 11 has a ICE for noexcept specification for `mpp::elements_compare`, so the noexcept specification doesn't exist for that CPO for Clang 11)
-  + NOTE: **Only works on Windows**, as Linux builds fail with this error (I haven't figured out how to fix this error):
-
-``` txt
-/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ranges:3392:19: error: missing 'typename' prior to dependent type name 'iterator_traits<iterator_t<_Base>>::iterator_category'
-```
-
 * MSVC 19.28
 
 ## How to Include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,8 +79,6 @@ jobs:
 
   - job: UbuntuClang
     displayName: Ubuntu Clang 11
-    # @TODO: Allow this when the bug is somehow identified...
-    # condition: false
 
     pool:
       vmImage: ubuntu-latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
   - job: UbuntuClang
     displayName: Ubuntu Clang 11
     # @TODO: Allow this when the bug is somehow identified...
-    condition: false
+    # condition: false
 
     pool:
       vmImage: ubuntu-latest

--- a/include/mpp/matrix/fully_static.hpp
+++ b/include/mpp/matrix/fully_static.hpp
@@ -29,7 +29,6 @@
 
 #include <concepts>
 #include <initializer_list>
-#include <ranges>
 #include <type_traits>
 #include <utility>
 


### PR DESCRIPTION
Since https://github.com/sam20908/mpp/commit/6fbdb739a06e0ce511b0256f812eb11d29c9fa9f identified an issue with Ubuntu Clang on CI, this workarounds that issue.