### PR TITLE
Clean up tests

### DIFF
--- a/external/tests/src/arithmetic.cpp
+++ b/external/tests/src/arithmetic.cpp
@@ -33,32 +33,15 @@ namespace
 	template<typename Mats, bool ConstructMat>
 	void test_op(std::string_view test_name, const auto& op)
 	{
-		test(test_name) = [&, test_name]<typename T,
-							  typename T2,
-							  typename T3,
-							  std::size_t RowsExtent,
-							  std::size_t RowsExtent2,
-							  std::size_t RowsExtent3,
-							  std::size_t ColumnsExtent,
-							  std::size_t ColumnsExtent2,
-							  std::size_t ColumnsExtent3,
-							  typename Alloc,
-							  typename Alloc2,
-							  typename Alloc3>(
-							  std::tuple<std::type_identity<matrix<T, RowsExtent, ColumnsExtent, Alloc>>,
-								  std::type_identity<matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>>,
-								  std::type_identity<matrix<T3, RowsExtent3, ColumnsExtent3, Alloc3>>>) {
-			using mat_t  = matrix<T, RowsExtent, ColumnsExtent, Alloc>;
-			using mat2_t = matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>;
-			using mat3_t = matrix<T3, RowsExtent3, ColumnsExtent3, Alloc3>;
-
+		test(test_name) = [&, test_name]<typename Mat, typename Mat2, typename Mat3>(
+							  std::tuple<std::type_identity<Mat>, std::type_identity<Mat2>, std::type_identity<Mat3>>) {
 			const auto [mat, mat2, expected_mat] =
-				parse_test(test_name, parse_mat<mat_t>, parse_mat<mat2_t>, parse_mat<mat3_t>);
+				parse_test(test_name, parse_mat<Mat>, parse_mat<Mat2>, parse_mat<Mat3>);
 
 			const auto out = [&]() {
 				if constexpr (ConstructMat)
 				{
-					return mat3_t{ op(mat, mat2) };
+					return Mat3{ op(mat, mat2) };
 				}
 				else
 				{
@@ -78,26 +61,15 @@ namespace
 	template<typename Mats, bool ConstructMat>
 	void test_num_op(const std::string& test_name, const auto& op)
 	{
-		test(test_name) = [&, test_name]<typename T,
-							  typename T2,
-							  std::size_t RowsExtent,
-							  std::size_t RowsExtent2,
-							  std::size_t ColumnsExtent,
-							  std::size_t ColumnsExtent2,
-							  typename Alloc,
-							  typename Alloc2>(
-							  std::tuple<std::type_identity<matrix<T, RowsExtent, ColumnsExtent, Alloc>>,
-								  std::type_identity<matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>>>) {
-			using mat_t  = matrix<T, RowsExtent, ColumnsExtent, Alloc>;
-			using mat2_t = matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>;
-
+		test(test_name) = [&, test_name]<typename Mat, typename Mat2>(
+							  std::tuple<std::type_identity<Mat>, std::type_identity<Mat2>>) {
 			const auto [mat, val, expected_mat] =
-				parse_test(test_name, parse_mat<mat_t>, parse_val<T>, parse_mat<mat2_t>);
+				parse_test(test_name, parse_mat<Mat>, parse_val<typename Mat::value_type>, parse_mat<Mat2>);
 
 			const auto out = [&]() {
 				if constexpr (ConstructMat)
 				{
-					return mat2_t{ op(mat, val) };
+					return Mat2{ op(mat, val) };
 				}
 				else
 				{

--- a/external/tests/src/customization.cpp
+++ b/external/tests/src/customization.cpp
@@ -166,18 +166,18 @@ int main()
 	// Putting semiregular test here because this test does all the constants/type checking stuff
 
 	scenario("CPOs should meet std::semiregular requirements") = []() {
-		expect(boost::ut::constant<std::semiregular<mpp::type_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::singular_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::square_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::block_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::determinant_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::inverse_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::transpose_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::size_compare_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::elements_compare_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::lu_decomposition_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::forward_substitution_t>>);
-		expect(boost::ut::constant<std::semiregular<mpp::back_substitution_t>>);
+		expect(constant<std::semiregular<mpp::type_t>>);
+		expect(constant<std::semiregular<mpp::singular_t>>);
+		expect(constant<std::semiregular<mpp::square_t>>);
+		expect(constant<std::semiregular<mpp::block_t>>);
+		expect(constant<std::semiregular<mpp::determinant_t>>);
+		expect(constant<std::semiregular<mpp::inverse_t>>);
+		expect(constant<std::semiregular<mpp::transpose_t>>);
+		expect(constant<std::semiregular<mpp::size_compare_t>>);
+		expect(constant<std::semiregular<mpp::elements_compare_t>>);
+		expect(constant<std::semiregular<mpp::lu_decomposition_t>>);
+		expect(constant<std::semiregular<mpp::forward_substitution_t>>);
+		expect(constant<std::semiregular<mpp::back_substitution_t>>);
 	};
 
 	return 0;

--- a/external/tests/src/iterator.cpp
+++ b/external/tests/src/iterator.cpp
@@ -121,30 +121,26 @@ int main()
         matrix<int, 2, dynamic>{ range_2d },
         matrix<int, dynamic, 3>{ range_2d } };
 
-	feature("Standard conforming iterators") =
-		[]<typename T, std::size_t RowsExtent, std::size_t ColumnsExtent, typename Alloc>(
-			std::type_identity<matrix<T, RowsExtent, ColumnsExtent, Alloc>>) {
-			using mat_t                  = matrix<T, RowsExtent, ColumnsExtent, Alloc>;
-			using mat_iter               = typename mat_t::iterator;
-			using mat_reverse_iter       = typename mat_t::iterator;
-			using mat_const_iter         = typename mat_t::const_iterator;
-			using mat_const_reverse_iter = typename mat_t::const_iterator;
+	feature("Standard conforming iterators") = []<typename Mat>(std::type_identity<Mat>) {
+		using mat_iter               = typename Mat::iterator;
+		using mat_reverse_iter       = typename Mat::iterator;
+		using mat_const_iter         = typename Mat::const_iterator;
+		using mat_const_reverse_iter = typename Mat::const_reverse_iterator;
 
-			given("Mutable and immutable iterators should meet contiguous_iterator") = [&]() {
-				expect(boost::ut::constant<std::contiguous_iterator<mat_iter>>);
-				expect(boost::ut::constant<std::contiguous_iterator<mat_const_iter>>);
-			};
+		given("Mutable and immutable iterators should meet contiguous_iterator") = [&]() {
+			expect(constant<std::contiguous_iterator<mat_iter>>);
+			expect(constant<std::contiguous_iterator<mat_const_iter>>);
+		};
 
-			given("Mutable and immutable reverse iterators should meet bidirectional_iterator") = [&]() {
-				expect(boost::ut::constant<std::bidirectional_iterator<mat_reverse_iter>>);
-				expect(boost::ut::constant<std::bidirectional_iterator<mat_const_reverse_iter>>);
-			};
+		given("Mutable and immutable reverse iterators should meet bidirectional_iterator") = [&]() {
+			expect(constant<std::bidirectional_iterator<mat_reverse_iter>>);
+			expect(constant<std::bidirectional_iterator<mat_const_reverse_iter>>);
+		};
 
-			given("Mutable iterators should meet output_iterator") = [&]() {
-				expect(boost::ut::constant<std::output_iterator<mat_iter, int>>);
-			};
-		} |
-		mats_types;
+		given("Mutable iterators should meet output_iterator") = [&]() {
+			expect(constant<std::output_iterator<mat_iter, int>>);
+		};
+	} | mats_types;
 
 	feature("Iterator semantics") = [&]() {
 		given("Mutable and immutable iterators should have right semantics") = [](const auto& mat) {

--- a/external/tests/src/members.cpp
+++ b/external/tests/src/members.cpp
@@ -34,10 +34,10 @@ int main()
 	using namespace mpp;
 
 	feature("Destructible (part of rule of five)") = []() {
-		expect(boost::ut::constant<std::is_destructible_v<matrix<int, 2, 3>>>);
-		expect(boost::ut::constant<std::is_destructible_v<matrix<int, dynamic, dynamic>>>);
-		expect(boost::ut::constant<std::is_destructible_v<matrix<int, dynamic, 3>>>);
-		expect(boost::ut::constant<std::is_destructible_v<matrix<int, 2, dynamic>>>);
+		expect(constant<std::is_destructible_v<matrix<int, 2, 3>>>);
+		expect(constant<std::is_destructible_v<matrix<int, dynamic, dynamic>>>);
+		expect(constant<std::is_destructible_v<matrix<int, dynamic, 3>>>);
+		expect(constant<std::is_destructible_v<matrix<int, 2, dynamic>>>);
 	};
 
 	const auto range_2d = std::vector<std::vector<int>>{ { 1, 2, 3 }, { 4, 5, 6 } };

--- a/external/tests/src/utilities.cpp
+++ b/external/tests/src/utilities.cpp
@@ -38,38 +38,22 @@ namespace
 	template<typename Mats>
 	void test_fn(std::string_view test_name, const auto& fn, const auto& parse_fn)
 	{
-		test(test_name.data()) =
-			[&, test_name]<typename T, std::size_t RowsExtent, std::size_t ColumnsExtent, typename Alloc>(
-				std::type_identity<matrix<T, RowsExtent, ColumnsExtent, Alloc>>) {
-				using mat_t = matrix<T, RowsExtent, ColumnsExtent, Alloc>;
+		test(test_name.data()) = [&, test_name]<typename Mat>(std::type_identity<Mat>) {
+			const auto [mat, expected_val] = parse_test(test_name, parse_mat<Mat>, parse_fn);
+			const auto out                 = fn(mat);
 
-				const auto [mat, expected_val] = parse_test(test_name, parse_mat<mat_t>, parse_fn);
-				const auto out                 = fn(mat);
-
-				expect(out == expected_val);
-			} |
-			Mats{};
+			expect(out == expected_val);
+		} | Mats{};
 	}
 
 	template<typename Mats, typename Order, typename Order2>
 	void test_cmp_size(std::string_view test_name)
 	{
-		test(test_name.data()) = [&, test_name]<typename T,
-									 typename T2,
-									 std::size_t RowsExtent,
-									 std::size_t RowsExtent2,
-									 std::size_t ColumnsExtent,
-									 std::size_t ColumnsExtent2,
-									 typename Alloc,
-									 typename Alloc2>(
-									 std::tuple<std::type_identity<matrix<T, RowsExtent, ColumnsExtent, Alloc>>,
-										 std::type_identity<matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>>>) {
-			using mat_t  = matrix<T, RowsExtent, ColumnsExtent, Alloc>;
-			using mat2_t = matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>;
-
+		test(test_name.data()) = [test_name]<typename Mat, typename Mat2>(
+									 std::tuple<std::type_identity<Mat>, std::type_identity<Mat2>>) {
 			const auto [mat, mat2, cmp_rows, cmp_cols, expected_row_cmp, expected_col_cmp] = parse_test(test_name,
-				parse_mat<mat_t>,
-				parse_mat<mat2_t>,
+				parse_mat<Mat>,
+				parse_mat<Mat2>,
 				parse_val<bool>,
 				parse_val<bool>,
 				parse_ordering<Order>,
@@ -85,21 +69,10 @@ namespace
 	template<typename Mats, typename Order>
 	void test_cmp_elems(std::string_view test_name)
 	{
-		test(test_name.data()) = [&, test_name]<typename T,
-									 typename T2,
-									 std::size_t RowsExtent,
-									 std::size_t RowsExtent2,
-									 std::size_t ColumnsExtent,
-									 std::size_t ColumnsExtent2,
-									 typename Alloc,
-									 typename Alloc2>(
-									 std::tuple<std::type_identity<matrix<T, RowsExtent, ColumnsExtent, Alloc>>,
-										 std::type_identity<matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>>>) {
-			using mat_t  = matrix<T, RowsExtent, ColumnsExtent, Alloc>;
-			using mat2_t = matrix<T2, RowsExtent2, ColumnsExtent2, Alloc2>;
-
+		test(test_name.data()) = [&, test_name]<typename Mat, typename Mat2>(
+									 std::tuple<std::type_identity<Mat>, std::type_identity<Mat2>>) {
 			const auto [mat, mat2, expected_cmp] =
-				parse_test(test_name, parse_mat<mat_t>, parse_mat<mat2_t>, parse_ordering<Order>);
+				parse_test(test_name, parse_mat<Mat>, parse_mat<Mat2>, parse_ordering<Order>);
 
 			const auto out = elements_compare(mat, mat2, floating_point_compare);
 


### PR DESCRIPTION
Cleans up tests to use new techniques and removes unnecessary namescape scoping.

Also fixes #346